### PR TITLE
added ValidateFluent() with default runtime-resolved validator

### DIFF
--- a/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
+++ b/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
@@ -2,6 +2,8 @@ using System;
 
 using FluentAssertions;
 
+using FluentValidation;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -107,11 +109,24 @@ namespace IL.FluentValidation.Extensions.Options.Tests
                 );
         }
 
+        [Fact]
+        public void FluentValidate_with_default_validator_will_pass()
+        {
+            Validate_passing_valid_options_will_pass(x => x.ValidateFluent());
+        }
+
+        [Fact]
+        public void FluentValidate_with_default_validator_will_throw_exception()
+        {
+            Validate_passing_invalid_options_will_throw_exception(x => x.ValidateFluent());
+        }
+
         private void Validate_passing_valid_options_will_pass(
             Func<OptionsBuilder<MyOptions>, OptionsBuilder<MyOptions>> addValidation
             )
         {
             var services = new ServiceCollection();
+            services.AddValidatorsFromAssemblyContaining<MyOptionsValidator>();
             var optionsBuilder = services.AddOptions<MyOptions>()
                 .Configure(options => options.TrueValue = true);
             addValidation(optionsBuilder);
@@ -125,6 +140,7 @@ namespace IL.FluentValidation.Extensions.Options.Tests
             )
         {
             var services = new ServiceCollection();
+            services.AddValidatorsFromAssemblyContaining<MyOptionsValidator>();
             var optionsBuilder = services.AddOptions<MyOptions>()
                 .Configure(options => options.TrueValue = false);
             addValidation(optionsBuilder);

--- a/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
+++ b/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
@@ -110,23 +110,34 @@ namespace IL.FluentValidation.Extensions.Options.Tests
         }
 
         [Fact]
-        public void FluentValidate_with_default_validator_will_pass()
+        public void FluentValidate_with_default_validator_passing_valid_options_will_pass()
         {
-            Validate_passing_valid_options_will_pass(x => x.ValidateFluent());
+            Validate_passing_valid_options_will_pass(
+                x => x.ValidateWithFluentValidator(),
+                addValidatorsFromAssembly: true
+                );
         }
 
         [Fact]
-        public void FluentValidate_with_default_validator_will_throw_exception()
+        public void FluentValidate_with_default_validator_passing_invalid_options_will_throw_exception()
         {
-            Validate_passing_invalid_options_will_throw_exception(x => x.ValidateFluent());
+            Validate_passing_invalid_options_will_throw_exception(
+                x => x.ValidateWithFluentValidator(),
+                addValidatorsFromAssembly: true
+                );
         }
 
         private void Validate_passing_valid_options_will_pass(
-            Func<OptionsBuilder<MyOptions>, OptionsBuilder<MyOptions>> addValidation
+            Func<OptionsBuilder<MyOptions>, OptionsBuilder<MyOptions>> addValidation,
+            bool addValidatorsFromAssembly = false
             )
         {
             var services = new ServiceCollection();
-            services.AddValidatorsFromAssemblyContaining<MyOptionsValidator>();
+            if (addValidatorsFromAssembly)
+            {
+                services.AddValidatorsFromAssemblyContaining(GetType());
+            }
+
             var optionsBuilder = services.AddOptions<MyOptions>()
                 .Configure(options => options.TrueValue = true);
             addValidation(optionsBuilder);
@@ -136,11 +147,16 @@ namespace IL.FluentValidation.Extensions.Options.Tests
         }
 
         private void Validate_passing_invalid_options_will_throw_exception(
-            Func<OptionsBuilder<MyOptions>, OptionsBuilder<MyOptions>> addValidation
+            Func<OptionsBuilder<MyOptions>, OptionsBuilder<MyOptions>> addValidation,
+            bool addValidatorsFromAssembly = false
             )
         {
             var services = new ServiceCollection();
-            services.AddValidatorsFromAssemblyContaining<MyOptionsValidator>();
+            if (addValidatorsFromAssembly)
+            {
+                services.AddValidatorsFromAssemblyContaining(GetType());
+            }
+
             var optionsBuilder = services.AddOptions<MyOptions>()
                 .Configure(options => options.TrueValue = false);
             addValidation(optionsBuilder);

--- a/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
+++ b/src/IL.FluentValidation.Extensions.Options.Tests/FluentValidationOptionsBuilderExtensionsTests.cs
@@ -135,7 +135,7 @@ namespace IL.FluentValidation.Extensions.Options.Tests
             var services = new ServiceCollection();
             if (addValidatorsFromAssembly)
             {
-                services.AddValidatorsFromAssemblyContaining(GetType());
+                services.AddValidatorsFromAssembly(GetType().Assembly);
             }
 
             var optionsBuilder = services.AddOptions<MyOptions>()
@@ -154,7 +154,7 @@ namespace IL.FluentValidation.Extensions.Options.Tests
             var services = new ServiceCollection();
             if (addValidatorsFromAssembly)
             {
-                services.AddValidatorsFromAssemblyContaining(GetType());
+                services.AddValidatorsFromAssembly(GetType().Assembly);
             }
 
             var optionsBuilder = services.AddOptions<MyOptions>()

--- a/src/IL.FluentValidation.Extensions.Options.Tests/IL.FluentValidation.Extensions.Options.Tests.csproj
+++ b/src/IL.FluentValidation.Extensions.Options.Tests/IL.FluentValidation.Extensions.Options.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
   </ItemGroup>
 

--- a/src/IL.FluentValidation.Extensions.Options/FluentValidationOptionsBuilderExtensions.cs
+++ b/src/IL.FluentValidation.Extensions.Options/FluentValidationOptionsBuilderExtensions.cs
@@ -79,9 +79,9 @@ namespace IL.FluentValidation.Extensions.Options
             return optionsBuilder;
         }
 
-        public static OptionsBuilder<TOptions> ValidateFluent<TOptions>(
+        public static OptionsBuilder<TOptions> ValidateWithFluentValidator<TOptions>(
             this OptionsBuilder<TOptions> optionsBuilder
-        )
+            )
             where TOptions : class
         {
             if (optionsBuilder == null)
@@ -89,7 +89,12 @@ namespace IL.FluentValidation.Extensions.Options
                 throw new ArgumentNullException(nameof(optionsBuilder));
             }
 
-            optionsBuilder.Services.AddTransient<IValidateOptions<TOptions>>(provider => new FluentValidationValidateOptions<TOptions>(optionsBuilder.Name, provider.GetRequiredService<IValidator<TOptions>>()));
+            optionsBuilder.Services.AddTransient<IValidateOptions<TOptions>>(serviceProvider =>
+            {
+                var validator = serviceProvider.GetRequiredService<IValidator<TOptions>>();
+                return new FluentValidationValidateOptions<TOptions>(optionsBuilder.Name, validator);
+            });
+
             return optionsBuilder;
         }
 

--- a/src/IL.FluentValidation.Extensions.Options/FluentValidationOptionsBuilderExtensions.cs
+++ b/src/IL.FluentValidation.Extensions.Options/FluentValidationOptionsBuilderExtensions.cs
@@ -79,6 +79,20 @@ namespace IL.FluentValidation.Extensions.Options
             return optionsBuilder;
         }
 
+        public static OptionsBuilder<TOptions> ValidateFluent<TOptions>(
+            this OptionsBuilder<TOptions> optionsBuilder
+        )
+            where TOptions : class
+        {
+            if (optionsBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(optionsBuilder));
+            }
+
+            optionsBuilder.Services.AddTransient<IValidateOptions<TOptions>>(provider => new FluentValidationValidateOptions<TOptions>(optionsBuilder.Name, provider.GetRequiredService<IValidator<TOptions>>()));
+            return optionsBuilder;
+        }
+
         public static FluentValidationOptionsBuilderWrapper<TOptions> FluentValidate<TOptions>(this OptionsBuilder<TOptions> optionsBuilder)
             where TOptions : class
             => new FluentValidationOptionsBuilderWrapper<TOptions>(optionsBuilder);


### PR DESCRIPTION
Usually one can simply register all validators calling 'AddValidatorsFromAssemblyContaining' or similar extensions from `FluentValidation.DependencyInjectionExtensions` package and then resolve any via `IValidator<T>`. So with this addition you can register validators via simple `.ValidateFluent()` call and not bother mentioning exact implementation.